### PR TITLE
Fix possible variable type mismatch error

### DIFF
--- a/org.eclim.core/vim/eclim/autoload/eclim/project/util.vim
+++ b/org.eclim.core/vim/eclim/autoload/eclim/project/util.vim
@@ -1033,6 +1033,7 @@ function! eclim#project#util#GetProjects() " {{{
       let results = eclim#Execute(
         \ s:command_projects, {'instance': instance})
       if type(results) != g:LIST_TYPE
+        unlet results
         continue
       endif
 


### PR DESCRIPTION
This fixes a bug on my machine, where "results" was not a list in the first iteration but was in the second, causing a variable type mismatch error in vim.
